### PR TITLE
Fixing typos, improving documentation for IOUIssueFlowTests regarding quasar

### DIFF
--- a/kotlin-source/src/main/kotlin/net/corda/training/contract/IOUContract.kt
+++ b/kotlin-source/src/main/kotlin/net/corda/training/contract/IOUContract.kt
@@ -7,7 +7,7 @@ import net.corda.core.transactions.LedgerTransaction
 import net.corda.training.state.IOUState
 
 /**
- * This is where you'll add the contract code which defines how the [IOUState] behaves. Looks at the unit tests in
+ * This is where you'll add the contract code which defines how the [IOUState] behaves. Look at the unit tests in
  * [IOUContractTests] for instructions on how to complete the [IOUContract] class.
  */
 class IOUContract : Contract {

--- a/kotlin-source/src/main/kotlin/net/corda/training/flow/IOUTransferFlow.kt
+++ b/kotlin-source/src/main/kotlin/net/corda/training/flow/IOUTransferFlow.kt
@@ -19,7 +19,7 @@ import net.corda.training.state.IOUState
 /**
  * This is the flow which handles transfers of existing IOUs on the ledger.
  * Gathering the counterparty's signature is handled by the [CollectSignaturesFlow].
- * Notarisation (if required) and commitment to the ledger is handled vy the [FinalityFlow].
+ * Notarisation (if required) and commitment to the ledger is handled by the [FinalityFlow].
  * The flow returns the [SignedTransaction] that was committed to the ledger.
  */
 @InitiatingFlow

--- a/kotlin-source/src/test/kotlin/net/corda/training/contract/IOUSettleTests.kt
+++ b/kotlin-source/src/test/kotlin/net/corda/training/contract/IOUSettleTests.kt
@@ -84,7 +84,7 @@ class IOUSettleTests {
     /**
      * Task 2.
      * For now, we only want to settle one IOU at once. We can use the [TransactionForContract.groupStates] function
-     * to group the IOUs by their [lienarId] property. We want to make sure there is only one group of input and output
+     * to group the IOUs by their [linearId] property. We want to make sure there is only one group of input and output
      * IOUs.
      * TODO: Using [groupStates] add a constraint that checks for one group of input/output IOUs.
      * Hint:
@@ -201,7 +201,7 @@ class IOUSettleTests {
      * Task 5.
      * Not only to we need to check that [Cash] output states are present but we need to check that the payer is
      * correctly assigning us as the new owner of these states.
-     * TODO: Add a constaint to check that we are the new owner of the output cash.
+     * TODO: Add a constraint to check that we are the new owner of the output cash.
      * Hint:
      * - Not all of the cash may be assigned to us as some of the input cash may be sent back to the payer as change.
      * - We need to use the [Cash.State.owner] property to check to see that it is the value of our public key.
@@ -417,7 +417,7 @@ class IOUSettleTests {
 
     /**
      * Task 10.
-     * Both the lender and the borrower must signed an IOU issue transaction.
+     * Both the lender and the borrower must have signed an IOU issue transaction.
      * TODO: Add a constraint to the contract code that ensures this is the case.
      */
 //    @Test

--- a/kotlin-source/src/test/kotlin/net/corda/training/flow/IOUIssueFlowTests.kt
+++ b/kotlin-source/src/test/kotlin/net/corda/training/flow/IOUIssueFlowTests.kt
@@ -17,7 +17,11 @@ import kotlin.test.assertFailsWith
 
 /**
  * Practical exercise instructions Flows part 1.
- * Uncomment the unit tests and use the hints + unit test body to complete the FLows such that the unit tests pass.
+ * Uncomment the unit tests and use the hints + unit test body to complete the Flows such that the unit tests pass.
+ * Note! These tests rely on Quasar to be loaded, set your run configuration to "-ea -javaagent:lib/quasar.jar"
+ * Run configuration can be edited in IntelliJ under Run -> Edit Configurations -> VM options
+ * On some machines/configurations you may have to provide a full path to the quasar.jar file.
+ * On some machines/configurations you may have to use the "JAR manifest" option for shortening the command line.
  */
 class IOUIssueFlowTests {
     lateinit var mockNetwork: MockNetwork
@@ -118,9 +122,9 @@ class IOUIssueFlowTests {
      * On the Initiator side:
      * - Get a set of signers required from the participants who are not the node
      * - - [ourIdentity] will give you the identity of the node you are operating as
-     * - Use [initateFlow] to get a set of [FlowSession] objects
+     * - Use [initiateFlow] to get a set of [FlowSession] objects
      * - - Using [state.participants] as a base to determine the sessions needed is recommended. [participants] is on
-     * - - the state interface so it is guaranteed to to exist where [lender] and [borrower] are not.
+     * - - the state interface so it is guaranteed to exist where [lender] and [borrower] are not.
      * - - Hint: [ourIdentity] will give you the [Party] that represents the identity of the initiating flow.
      * - Use [subFlow] to start the [CollectSignaturesFlow]
      * - Pass it a [SignedTransaction] object and [FlowSession] set

--- a/kotlin-source/src/test/kotlin/net/corda/training/flow/IOUSettleFlowTests.kt
+++ b/kotlin-source/src/test/kotlin/net/corda/training/flow/IOUSettleFlowTests.kt
@@ -62,7 +62,7 @@ class IOUSettleFlowTests {
     }
 
     /**
-     * Issue an some on-ledger cash to ourselves, we need to do this before we can Settle an IOU.
+     * Issue some on-ledger cash to ourselves, we need to do this before we can Settle an IOU.
      */
     private fun issueCash(amount: Amount<Currency>): Cash.State {
         val flow = SelfIssueCashFlow(amount)

--- a/kotlin-source/src/test/kotlin/net/corda/training/flow/IOUTransferFlowTests.kt
+++ b/kotlin-source/src/test/kotlin/net/corda/training/flow/IOUTransferFlowTests.kt
@@ -20,7 +20,7 @@ import kotlin.test.assertFailsWith
 
 /**
  * Practical exercise instructions Flows part 2.
- * Uncomment the unit tests and use the hints + unit test body to complete the FLows such that the unit tests pass.
+ * Uncomment the unit tests and use the hints + unit test body to complete the Flows such that the unit tests pass.
  */
 class IOUTransferFlowTests {
     lateinit var mockNetwork: MockNetwork


### PR DESCRIPTION
Some direct typos fixed.
In addition, IOUIssueFlowTests requires quasar to run properly, I had issues adding quasar to the run configuration and thought this might be helpful to others as well.
Also while using classpath file to shorten the command line, quasar was not located correctly, only using "JAR manifest" to shorten the command line worked.