### PR TITLE
Update README command to run nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ interact with it via a web browser. To run the finished application, you have tw
 
 ### Kotlin
 * Terminal: Navigate to the root project folder and run `./gradlew kotlin-source:deployNodes`, followed by 
-`./kotlin-source/build/node/runnodes`
+`./kotlin-source/build/nodes/runnodes`
 * IntelliJ: With the project open, select `Kotlin - Node driver` from the dropdown run configuration menu, and click 
 the green play button.
 


### PR DESCRIPTION
This seems to be outdated (maybe since the Corda 4 upgrade?). It seems likely that the Java section slightly lower down in the README also needs to be updated.