### PR TITLE
Add test for settling partially paid iou

### DIFF
--- a/kotlin-source/src/test/kotlin/net/corda/training/contract/IOUSettleTests.kt
+++ b/kotlin-source/src/test/kotlin/net/corda/training/contract/IOUSettleTests.kt
@@ -366,6 +366,14 @@ class IOUSettleTests {
 //                command(listOf(ALICE.publicKey, BOB.publicKey), IOUContract.Commands.Settle())
 //                verifies()
 //            }
+//            transaction {
+//                input(Cash.PROGRAM_ID, fiveDollars)
+//                input(IOUContract.IOU_CONTRACT_ID, iou.pay(5.DOLLARS))
+//                output(Cash.PROGRAM_ID, fiveDollars.withNewOwner(newOwner = ALICE.party).ownableState)
+//                command(BOB.publicKey, fiveDollars.withNewOwner(newOwner = BOB.party).command)
+//                command(listOf(ALICE.publicKey, BOB.publicKey), IOUContract.Commands.Settle())
+//                verifies()
+//            }
 //        }
 //    }
 


### PR DESCRIPTION
We don't want an output IOU if the input is being fully settled.
The comparison in this case should be against the outstanding amount of the IOU, not the total amount.
Without this test the contract could only be performing this check against the total amount of the IOU and still passing all tests